### PR TITLE
Update haskell.nix pin

### DIFF
--- a/pins/default-haskell-nix.json
+++ b/pins/default-haskell-nix.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/haskell.nix",
-  "rev": "b390b34e1842acf9146351d2fb2d1a5c0bfa556b",
-  "date": "2019-12-13T16:11:00+08:00",
-  "sha256": "13iwkd11wggbx59camcjwrd1cr6r9jcbpdhqy8l2f8janl1i2pp8",
+  "rev": "801f05fa175d07bf9e4542bfd558180072288fe6",
+  "date": "2020-01-15T01:10:14+00:00",
+  "sha256": "1nn7j9vpgcxhgfrdn70g53759wb8m9p350m6srq32v73jhl4a8ar",
   "fetchSubmodules": false
 }


### PR DESCRIPTION
This pulls in https://github.com/input-output-hk/haskell.nix/pull/397 (automatically generate cache for stackage projects).