### PR TITLE
Use Unix implementation of x509-system on Darwin

### DIFF
--- a/overlays/darwin.nix
+++ b/overlays/darwin.nix
@@ -1,0 +1,15 @@
+self: super:
+{
+  haskell-nix = super.haskell-nix // (
+    {
+      defaultModules = super.haskell-nix.defaultModules ++ [
+        (
+          { pkgs, buildModules, config, lib, ... }:
+            {
+              packages.x509-system.patches = pkgs.stdenv.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [ ./patches/x509-system.patch ];
+            }
+        )
+      ];
+    }
+  );
+}

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -4,6 +4,7 @@ let
     [
       (import ./pin-stackage.nix)
       (import ./icu.nix)
+      (import ./darwin.nix)
       (import ./earnestresearch.nix)
     ];
 in

--- a/overlays/patches/x509-system.patch
+++ b/overlays/patches/x509-system.patch
@@ -1,0 +1,26 @@
+diff --git x509-system/System/X509.hs x509-system/System/X509.hs
+index 57e004b..5dccad0 100644
+--- x509-system/System/X509.hs
++++ x509-system/System/X509.hs
+@@ -12,8 +12,6 @@ module System.X509
+ 
+ #if defined(WINDOWS)
+ import System.X509.Win32
+-#elif defined(MACOSX)
+-import System.X509.MacOS
+ #else
+ import System.X509.Unix
+ #endif
+diff --git x509-system/System/X509/Unix.hs x509-system/System/X509/Unix.hs
+index 5c7b25f..85a84f1 100644
+--- x509-system/System/X509/Unix.hs
++++ x509-system/System/X509/Unix.hs
+@@ -34,7 +34,7 @@ defaultSystemPaths =
+     ]
+ 
+ envPathOverride :: String
+-envPathOverride = "SYSTEM_CERTIFICATE_PATH"
++envPathOverride = "NIX_SSL_CERT_FILE"
+ 
+ getSystemCertificateStore :: IO CertificateStore
+ getSystemCertificateStore = mconcat . catMaybes <$> (getSystemPaths >>= mapM readCertificateStore)


### PR DESCRIPTION
Would prefer to leverage Unix implementation of x509-system, which will allow people to depend on cacert package.

Alternative would be to hack system to call /usr/bin/system, but that depends on non-pure builds, and can't be managed by nix.

Modifies x509-system to also use NIX_SSL_CERT_FILE env variable instead of SYSTEM_CERTIFICATE_PATH, this matches the rest of nix.