### PR TITLE
Add CI with GH Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: [pull_request, push]
+on: [pull_request]
 
 jobs:
   tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Test
+
+on: [pull_request, push]
+
+jobs:
+  tests:
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v1
+    - uses: cachix/install-nix-action@v6
+    - uses: cachix/cachix-action@v3
+      with:
+        name: earnestresearch-oss
+        signingKey: '${{ secrets.OSS_CACHIX_SIGNING_KEY }}'
+        file: ci.nix

--- a/ci.nix
+++ b/ci.nix
@@ -1,4 +1,1 @@
-with (import ./. {});
-
-# Build nix-tools in CI
-pkgs.haskell-nix.nix-tools
+(import ./.).pkgs.haskell-nix.nix-tools

--- a/ci.nix
+++ b/ci.nix
@@ -1,1 +1,6 @@
-(import ./.).pkgs.haskell-nix.nix-tools
+with (import ./.);
+
+{
+  nix-tools = pkgs.haskell-nix.nix-tools;
+  inherit (pkgs.haskell-nix.compiler) ghc865;
+}

--- a/ci.nix
+++ b/ci.nix
@@ -1,0 +1,4 @@
+with (import ./. {});
+
+# Build nix-tools in CI
+pkgs.haskell-nix.nix-tools


### PR DESCRIPTION
Tries to build nix-tools (which should be responsible for a large part of recompilation when dependencies are bumped).