### PR TITLE
Build on macos-10.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-10.14, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Our builds have [started failing](https://github.com/EarnestResearch/er-nix/runs/417885781) on macos-latest.

```
  /nix/var/nix/profiles/default/bin/nix-build ci.nix
  error: could not set permissions on '/nix/var/nix/profiles/per-user' to 755: Operation not permitted
  ##[error]Action failed with error: Error: The process '/nix/var/nix/profiles/default/bin/nix-build' failed with exit code 1
```

Suspecting this is a Catalina+Nix problem, though it's not obvious which version the build is running on.  But explicitly downgrading to macos-10.14 solves it for now.