### PR TITLE
Revert "Build on macos-10.14"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        os: [macos-10.14, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
This reverts commit 63c5d3b4e9b3ee81d9de64a977d9e762512dbd75.

Builds are still hanging waiting for macos-latest.  The GitHub Actions blog states that [Mojave was dropped in October](https://github.blog/changelog/2019-10-31-github-actions-macos-virtual-environment-is-updating-to-catalina-and-dropping-mojave-support/), and there is [no mention of support](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources) for it now.

The [macos-10.14 build](https://github.com/EarnestResearch/er-nix/runs/418147136#step:4:116) _did_ appear to do something, but it working seems to be accidental.