### PR TITLE
Update install-nix-action to latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1
-    - uses: cachix/install-nix-action@v6
+    - uses: cachix/install-nix-action@releases/v7
     - uses: cachix/cachix-action@v3
       with:
         name: earnestresearch-oss


### PR DESCRIPTION
This version of install-nix-action uses a volume rather than symlink, and should also fix race conditions on build (with MacOS). Building via a symlink was always incorrect, and could build bad derivations.