### PR TITLE
cachix-action@v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: cachix/install-nix-action@releases/v7
-    - uses: cachix/cachix-action@v3
+    - uses: cachix/cachix-action@v4
       with:
         name: earnestresearch-public
         signingKey: '${{ secrets.EARNESTRESEARCH_PUBLIC_CACHIX_SIGNING_KEY }}'


### PR DESCRIPTION
Fixes the intermittent /nix/var/nix/profiles/per-user permission bug on MacOS.