### PR TITLE
Remove icu package aliases

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,6 +1,5 @@
 # All local overlays provided by er-nix.
 [
-  (import ./icu.nix)
   (import ./darwin.nix)
   (import ./eksctl.nix)
   (import ./custom-packages.nix)

--- a/overlays/icu.nix
+++ b/overlays/icu.nix
@@ -1,5 +1,0 @@
-self: _: {
-  icuuc = self.icu;
-  icui18n = self.icu;
-  icudata = self.icu;
-}


### PR DESCRIPTION
These are now present in lib/system-nixpkgs-map.nix in haskell.nix