### PR TITLE
Build ghc from pkgs.buildPackages.pkgs.haskell-nix.compiler

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -3,5 +3,5 @@ with (import ./.);
 
 {
   nix-tools = pkgs.haskell-nix.nix-tools;
-  ghc = builtins.getAttr ghc pkgs.haskell-nix.compiler;
+  ghc = builtins.getAttr ghc pkgs.buildPackages.pkgs.haskell-nix.compiler;
 }


### PR DESCRIPTION
This causes the ghc to be taken from the build platform, rather than from the target platform, this matters for cross-compilation.