### PR TITLE
Bump all dependencies

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "fc31134a3de7a82a9c14a70426a7fda68a26f41a",
-        "sha256": "17nhnxj7lg92yb8ngylmqd2ly2vkgi0mg6h5pnhgn4w4mxs17rly",
+        "rev": "a29ef5689d1dc70b930c0f188b9aa97193211d6a",
+        "sha256": "108bv45cchjbxcx27a45j7r6h6if80v0ll1r0m4b2x4qsyxcn9ic",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/fc31134a3de7a82a9c14a70426a7fda68a26f41a.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/a29ef5689d1dc70b930c0f188b9aa97193211d6a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {
@@ -36,15 +36,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "nixos-19.09",
+        "branch": "nixos-20.03",
         "description": "Nix Packages collection",
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f6c1d3b113ce9e7c908991df2e8eed02f03df1bc",
-        "sha256": "08z6qbjmx64bcil3cnvflb7bv9ibdizxcr63yvhgcqzsja7m51n5",
+        "rev": "82b5f87fcc710a99c47c5ffe441589807a8202af",
+        "sha256": "0wz07gzapdj95h9gf0rdc2ywgd7fnaivnf4vhwyh5gx24dblg7q8",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/f6c1d3b113ce9e7c908991df2e8eed02f03df1bc.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/82b5f87fcc710a99c47c5ffe441589807a8202af.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-unstable": {
@@ -53,22 +53,22 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "29a98f2be1961d84024c406fd437e223fb108087",
-        "sha256": "170jzjpx0gibnfkb3q5lyqdcana0n97nsgi8fycszh7k596nbdql",
+        "rev": "698e71db2c47b5d3a206c65288f88ab4320eaf1e",
+        "sha256": "1lwlxjb38mis83hfi6d4i8yrblb31zvk5ff5wx9csghbk2pki9w1",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/29a98f2be1961d84024c406fd437e223fb108087.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/698e71db2c47b5d3a206c65288f88ab4320eaf1e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {
         "branch": "master",
         "description": "Seamless integration of https://pre-commit.com git hooks with Nix.",
         "homepage": "",
-        "owner": "hercules-ci",
+        "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "77dd75709bbf33e2fc769dae08bab04a61ae409c",
-        "sha256": "0p60mc6a5fv7kplqciq1m0ql8azhx5xbxvc0n67jdw4j33n9a496",
+        "rev": "f709c4652d4696dbe7c6a8354ebd5938f2bf807b",
+        "sha256": "0700c5awc2gjzgikhx69vjbpyshx6b5xljmpxrdzpgqyg3blxbkl",
         "type": "tarball",
-        "url": "https://github.com/hercules-ci/pre-commit-hooks.nix/archive/77dd75709bbf33e2fc769dae08bab04a61ae409c.tar.gz",
+        "url": "https://github.com/cachix/pre-commit-hooks.nix/archive/f709c4652d4696dbe7c6a8354ebd5938f2bf807b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
Including:
 - move nixpkgs to 20.03
 - move haskell.nix to latest
 - move pre-commit-hooks to latest, owner from hercules-ci to cachix