### PR TITLE
Build ghcide in CI

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -1,7 +1,9 @@
 { ghc }:
 with (import ./.);
-
 {
   nix-tools = pkgs.haskell-nix.nix-tools;
-  ghc = builtins.getAttr ghc pkgs.buildPackages.pkgs.haskell-nix.compiler;
+  ghcide = pkgs.haskell-nix.tool "ghcide" {
+    version = "object-code";
+    compiler-nix-name = ghc;
+  };
 }


### PR DESCRIPTION
This builds ghcide for supplied ghc versions (continues to build ghc implicitly).