### PR TITLE
Fix cross-build from MacOS to other systems

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -39,12 +39,12 @@
         "branch": "nixos-20.03",
         "description": "Nix Packages collection",
         "homepage": "https://github.com/NixOS/nixpkgs",
-        "owner": "NixOS",
+        "owner": "EarnestResearch",
         "repo": "nixpkgs",
-        "rev": "2b417708c282d84316366f4125b00b29c49df10f",
-        "sha256": "0426qaxw09h0kkn5zwh126hfb2j12j5xan6ijvv2c905pqi401zq",
+        "rev": "fecbd007fcb307ae0d5039f48d468e7642a7c8de",
+        "sha256": "0m95kb36cb86vdnqr2lb1i1n281ddaikn5kgzrq5kdnqsyhq0wpd",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/2b417708c282d84316366f4125b00b29c49df10f.tar.gz",
+        "url": "https://github.com/EarnestResearch/nixpkgs/archive/fecbd007fcb307ae0d5039f48d468e7642a7c8de.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-unstable": {


### PR DESCRIPTION
When trying to cross-build from MacOS to Musl, some MacOS flags leaked into flags passed to the musl linker. This cherry-picks an upstream change that hasn't been merged to nixos-20.03 yet.