### PR TITLE
Latest skopeo release with a patch

### DIFF
--- a/applications/upload_docker_to_aws/default.nix
+++ b/applications/upload_docker_to_aws/default.nix
@@ -58,13 +58,13 @@ writeShellScriptBin "upload_docker_to_aws"
       exit 1
     fi
 
-    AUTH=''$(${awscli}/bin/aws ecr get-authorization-token --output text --query 'authorizationData[]')
+    AUTH=$(${awscli}/bin/aws ecr get-authorization-token --output text --query 'authorizationData[]')
 
     TOKEN=$( ${coreutils}/bin/echo $AUTH | ${gawk}/bin/awk '{ print $1 }' | ${coreutils}/bin/base64 -d | ${coreutils}/bin/cut -d: -f2 )
     DOCKER_HOST=$( ${coreutils}/bin/echo $AUTH | ${gawk}/bin/awk '{ print $3 }' | cut -d/ -f3 )
     DOCKER_URL="$DOCKER_HOST/$NAME:$TAG"
 
-    ${skopeo}/bin/skopeo copy "--dest-creds=AWS:$TOKEN" "docker-archive:$1" "docker://$DOCKER_URL" >&2
+    ${skopeo}/bin/skopeo copy --retry-times 5 --insecure-policy "--dest-creds=AWS:$TOKEN" "docker-archive:$1" "docker://$DOCKER_URL" >&2
 
     ${coreutils}/bin/echo "$DOCKER_URL"
   ''

--- a/overlays/custom-packages.nix
+++ b/overlays/custom-packages.nix
@@ -3,4 +3,5 @@ self: super:
 {
   aws-logs = self.callPackage ../pkgs/aws-logs {};
   okta-aws-login = self.callPackage ../pkgs/okta-aws-login {};
+  skopeo = self.callPackage ../pkgs/skopeo {};
 }

--- a/overlays/patches/skopeo.patch
+++ b/overlays/patches/skopeo.patch
@@ -1,0 +1,11 @@
+--- a/vendor/github.com/containers/image/v5/pkg/tlsclientconfig/tlsclientconfig.go
++++ b/vendor/github.com/containers/image/v5/pkg/tlsclientconfig/tlsclientconfig.go
+@@ -100,7 +100,7 @@ func NewTransport() *http.Transport {
+ 	tr := &http.Transport{
+ 		Proxy:               http.ProxyFromEnvironment,
+ 		DialContext:         direct.DialContext,
+-		TLSHandshakeTimeout: 10 * time.Second,
++		TLSHandshakeTimeout: 30 * time.Second,
+ 		// TODO(dmcgowan): Call close idle connections when complete and use keep alive
+ 		DisableKeepAlives: true,
+ 	}

--- a/pkgs/skopeo/default.nix
+++ b/pkgs/skopeo/default.nix
@@ -1,0 +1,61 @@
+{ stdenv
+, buildGoModule
+, fetchFromGitHub
+, runCommand
+, gpgme
+, lvm2
+, btrfs-progs
+, pkg-config
+, go-md2man
+, installShellFiles
+, makeWrapper
+, fuse-overlayfs
+, nixosTests
+}:
+
+buildGoModule rec {
+  pname = "skopeo";
+  version = "1.1.1.0";
+
+  src = builtins.fetchGit {
+    url = "https://github.com/containers/skopeo.git";
+    ref = "refs/heads/master";
+    rev = "c052ed7ec8622187679ff067d795acbdd45e4530";
+  };
+
+  patches = [ ../../overlays/patches/skopeo.patch ];
+
+  outputs = [ "out" "man" ];
+
+  vendorSha256 = null;
+
+  nativeBuildInputs = [ pkg-config go-md2man installShellFiles makeWrapper ];
+
+  buildInputs = [ gpgme ]
+  ++ stdenv.lib.optionals stdenv.isLinux [ lvm2 btrfs-progs ];
+
+  buildPhase = ''
+    patchShebangs .
+    make bin/skopeo
+  '';
+
+  installPhase = ''
+    make install-binary PREFIX=$out
+    make install-docs MANINSTALLDIR="$man/share/man"
+    installShellCompletion --bash completions/bash/skopeo
+  '';
+
+  postInstall = stdenv.lib.optionals stdenv.isLinux ''
+    wrapProgram $out/bin/skopeo \
+      --prefix PATH : ${stdenv.lib.makeBinPath [ fuse-overlayfs ]}
+  '';
+
+  passthru.tests.docker-tools = nixosTests.docker-tools;
+
+  meta = with stdenv.lib; {
+    description = "A command line utility for various operations on container images and image repositories";
+    homepage = "https://github.com/containers/skopeo";
+    maintainers = with maintainers; [ lewo ] ++ teams.podman.members;
+    license = licenses.asl20;
+  };
+}


### PR DESCRIPTION
This is to work around a dumb misleading CD error that is caused by

run-upload-to-aws> DEBU[0035] Ping
https://766386692293.dkr.ecr.us-east-1.amazonaws.com/v2/ err Get
"https://766386692293.dkr.ecr.us-east-1.amazonaws.com/v2/": net/http:
TLS handshake timeout (&url.Error{Op:"Get",
URL:"https://766386692293.dkr.ecr.us-east-1.amazonaws.com/v2/",
Err:http.tlsHandshakeTimeoutError{}})

but looks like

 FATA[0044] Error trying to reuse blob
sha256:3ff4f624486be56399049b6aa89fd0eafc14be2d92ce15cfa86355413a281e15
at destination: can't talk to a V1 docker registry

This is the dumb way docker client negotiates registry version.

Master version gives us --retry-times, which may also help in CD.
Patch gives us increased default TLS timeout.
It's unclear atm why the default value is not enough, requires further
investigation. Could be down to the number of root certs it ends up
parsing. People report similar errors with other Go tools.