### PR TITLE
Upgrade hpack to 0.34.2

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -2,5 +2,6 @@
 [
   (import ./darwin.nix)
   (import ./custom-packages.nix)
+  (import ./hpack.nix)
   (import ./earnestresearch.nix)
 ]

--- a/overlays/hpack.nix
+++ b/overlays/hpack.nix
@@ -1,0 +1,12 @@
+self: super:
+{
+  haskell = super.haskell // {
+    packages = super.haskell.packages // {
+      ghc865 = super.haskell.packages.ghc865.override {
+        overrides = hself: hsuper: {
+          hpack = self.haskell-nix.tool "ghc865" "hpack" "0.34.2";
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Puts a version of hpack in `pkgs.haskellPackages` that doesn't require the hash that's causing us merge conflicts in the cabal file on a handful of projects.  Inelegant, but temporary.