### PR TITLE
Rename hpack to hpack_0_34

### DIFF
--- a/overlays/hpack.nix
+++ b/overlays/hpack.nix
@@ -4,7 +4,7 @@ self: super:
     packages = super.haskell.packages // {
       ghc865 = super.haskell.packages.ghc865.override {
         overrides = hself: hsuper: {
-          hpack = self.haskell-nix.tool "ghc865" "hpack" "0.34.2";
+          hpack_0_34 = self.haskell-nix.tool "ghc865" "hpack" "0.34.2";
         };
       };
     };


### PR DESCRIPTION
Overriding hpack causes our ci.nix builds fail building pantry for lack of an hpack >= 0.31.2. :shrug: 

Referring to this new `hpack_0_34` in the project's default.nix, instead of more naturally referring to an overridden one, fixes the problem.