### PR TITLE
Add haskell-language-server tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,30 @@ and then add `cabal new-run` shell wrappers for all executables defined in your 
 * [`haskell-nix`](https://input-output-hk.github.io/haskell.nix/)
 * [`okta-aws-login`](https://github.com/EarnestResearch/okta-aws-login)
 
+## Tools
+
+We also add some development tools in `er-nix.tools`.
+One reason they're distinct from packages is that they may require arguments to configure.
+`pkgs.haskell-nix.tool` provides a lot, so this is mainly a holding area for things that aren't yet there.
+
+### haskell-language-server
+
+[Haskell Language Server](https://github.com/haskell/haskell-language-server) is a language server implementation that should work in any editor with an LSP client.
+It must be compiled with the same version of `ghc` as used by the project.
+The one provided here is sourced with our `haskell.nix`, and should work well with any of our `haskell.nix` projects.
+The nix name of the GHC compiler must be provided as an argument.
+To add it to your `shell.nix`:
+
+```nix
+let
+  compiler-nix-name = hsPkgs.earnest-project.project.pkg-set.options.compiler.nix-name.value;
+  hls = er-nix.tools.haskell-language-server compiler-nix-name;
+in
+hsPkgs.shellFor {
+  buildInputs = [ ... ] ++ builtins.attrValues hls;
+}
+```
+
 ## Development
 
 ### Updating sources

--- a/default.nix
+++ b/default.nix
@@ -28,4 +28,11 @@ rec {
   overlays = haskell-nix.overlays ++ (import ./overlays);
 
   inherit (import sources.niv {}) niv;
+
+  tools = {
+    haskell-language-server =
+      pkgs.callPackage ./tools/haskell-language-server {
+        inherit sources;
+      };
+  };
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -11,6 +11,18 @@
         "url": "https://github.com/infinisil/all-hies/archive/534ac517b386821b787d1edbd855b9966d0c0775.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "haskell-language-server": {
+        "branch": "0.4.0",
+        "description": "Integration point for ghcide and haskell-ide-engine. One IDE to rule them all.",
+        "homepage": null,
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "0a18edde24923251a148cbbc0ae993a6aac83b9c",
+        "sha256": "0b94l6bywa6jk20y2cswyq5ks4g515895k2apvr1mdfkfhngdb7b",
+        "type": "tarball",
+        "url": "https://github.com/haskell/haskell-language-server/archive/0a18edde24923251a148cbbc0ae993a6aac83b9c.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "haskell-nix": {
         "branch": "master",
         "description": "Alternative Haskell Infrastructure for Nixpkgs",
@@ -33,6 +45,18 @@
         "sha256": "0dplsk4sak4fw2hhw2rajg0pymvhs3m88gzpzqvhhnmzvfl3ki59",
         "type": "tarball",
         "url": "https://github.com/nmattia/niv/archive/24eabfbfaa74117d66fa27463a90b237b1b01746.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "nix-hls": {
+        "branch": "master",
+        "description": "Nix builds of Haskell Language Server",
+        "homepage": null,
+        "owner": "shajra",
+        "repo": "nix-hls",
+        "rev": "ab7f2a16174db741d7525dd61e68b3f8f8e926b3",
+        "sha256": "01ganaqf9gg7a1dw1snhkq4dmfwxln6jhdig3iq1q7slcfdqlrg2",
+        "type": "tarball",
+        "url": "https://github.com/shajra/nix-hls/archive/ab7f2a16174db741d7525dd61e68b3f8f8e926b3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {

--- a/tools/haskell-language-server/default.nix
+++ b/tools/haskell-language-server/default.nix
@@ -1,0 +1,9 @@
+{ sources }:
+
+ghcVersion: import sources.nix-hls {
+  inherit ghcVersion;
+  sources = {
+    inherit (sources) haskell-language-server;
+    "haskell.nix" = sources.haskell-nix;
+  };
+}


### PR DESCRIPTION
This is working great for me in Emacs with a nix process wrapper.  I don't know what adding it directly to the nix-shell will do for VSCode users, although it strikes me as the right thing to do with all the GHCs floating around here.

Discuss.