### PR TITLE
Fetch submodule of haskell-language-server

### DIFF
--- a/tools/haskell-language-server/default.nix
+++ b/tools/haskell-language-server/default.nix
@@ -1,9 +1,19 @@
-{ sources }:
+{ fetchFromGitHub,
+  sources }:
 
 ghcVersion: import sources.nix-hls {
   inherit ghcVersion;
   sources = {
-    inherit (sources) haskell-language-server;
+    # This has a submodule, which niv doesn't yet handle.
+    # Note that this also defeats nix-prefetch-git.
+    # https://github.com/nmattia/niv/issues/229
+    haskell-language-server =
+      with sources.haskell-language-server;
+      fetchFromGitHub {
+        inherit owner repo rev sha256;
+        name = "haskell-language-server-src";
+        fetchSubmodules = true;
+      };
     "haskell.nix" = sources.haskell-nix;
   };
 }


### PR DESCRIPTION
This is heinous.  haskell-language-server has a submodule, which isn't fetched by default, and doesn't contribute to the sha256.  But it doesn't build unless we fetch that submodule.  A similar workaround exists in the upstream nix-hls.

It worked for me because I'd already built directly from nix-hls, and had it cached under that sha256.  I don't think it's going to work for anybody else until we merge this.