### PR TITLE
Parameterize index state of hls

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,24 +157,18 @@ One reason they're distinct from packages is that they may require arguments to 
 
 [Haskell Language Server](https://github.com/haskell/haskell-language-server) is a language server implementation that should work in any editor with an LSP client.
 It must be compiled with the same version of `ghc` as used by the project.
-The one provided here is sourced with our `haskell.nix`, and should work well with any of our `haskell.nix` projects.
-The nix name of the GHC compiler must be provided as an argument.
+We provide a function here to build HLS binaries for your `haskell.nix` project.
+The nix name of your GHC and the Hackage index state are inferred from the project.
 To add it to your `shell.nix`:
 
 ```nix
 let
-  compiler-nix-name = hsPkgs.earnest-project.project.pkg-set.options.compiler.nix-name.value;
-  hls = er-nix.tools.haskell-language-server {
-    ghcVersion = compiler-nix-name;
-  };
+  hls = er-nix.tools.haskell-language-server { project = hsPkgs.earnest-project };
 in
 hsPkgs.shellFor {
   buildInputs = [ ... ] ++ builtins.attrValues hls;
 }
 ```
-
-`haskell-language-server` also accepts `index-state` and `index-sha256` arguments that should match your call to `cabalProject`.
-If you didn't specify them in default.nix, you should be able to cheerfully ignore them here.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -164,12 +164,17 @@ To add it to your `shell.nix`:
 ```nix
 let
   compiler-nix-name = hsPkgs.earnest-project.project.pkg-set.options.compiler.nix-name.value;
-  hls = er-nix.tools.haskell-language-server compiler-nix-name;
+  hls = er-nix.tools.haskell-language-server {
+    ghcVersion = compiler-nix-name;
+  };
 in
 hsPkgs.shellFor {
   buildInputs = [ ... ] ++ builtins.attrValues hls;
 }
 ```
+
+`haskell-language-server` also accepts `index-state` and `index-sha256` arguments that should match your call to `cabalProject`.
+If you didn't specify them in default.nix, you should be able to cheerfully ignore them here.
 
 ## Development
 

--- a/tools/haskell-language-server/default.nix
+++ b/tools/haskell-language-server/default.nix
@@ -1,8 +1,17 @@
-{ fetchFromGitHub,
-  sources }:
+{ fetchFromGitHub
+, haskell-nix
+, lib
+, sources
+}:
 
-ghcVersion: import sources.nix-hls {
-  inherit ghcVersion;
+let
+  index-state-hashes = import haskell-nix.indexStateHashesPath;
+in
+{ ghcVersion
+, index-state ? lib.last (builtins.attrNames index-state-hashes)
+, index-sha256 ? null
+}: import sources.nix-hls {
+  inherit ghcVersion index-state index-sha256;
   sources = {
     # This has a submodule, which niv doesn't yet handle.
     # Note that this also defeats nix-prefetch-git.

--- a/tools/haskell-language-server/default.nix
+++ b/tools/haskell-language-server/default.nix
@@ -1,16 +1,18 @@
 { fetchFromGitHub
-, haskell-nix
-, lib
 , sources
 }:
 
+{ project
+, # We can't infer this, which is fine as long as we're using a hashed
+  # one.  We're just overriding nix-hls' pin here so haskell.nix looks
+  # it up in its own indexStateHashesPath.
+  index-sha256 ? null
+}:
 let
-  index-state-hashes = import haskell-nix.indexStateHashesPath;
+  ghcVersion = project.project.pkg-set.options.compiler.nix-name.value;
+  index-state = project.project.index-state;
 in
-{ ghcVersion
-, index-state ? lib.last (builtins.attrNames index-state-hashes)
-, index-sha256 ? null
-}: import sources.nix-hls {
+import sources.nix-hls {
   inherit ghcVersion index-state index-sha256;
   sources = {
     # This has a submodule, which niv doesn't yet handle.


### PR DESCRIPTION
Reimagines the haskell-language-server tool as a function of the cabal project we're trying to build it for.

I think the reason our template is recompiling a fresh GHC is because nix-hls is explicitly pinned to a hackage index, whereas we're using the default from our haskell.nix.  This aligns things so both the main project and the HLS are on not just the same nominal GHC version, but the same Hackage index.