### PR TITLE
Inline nix-hls to make REALLY SURE our packages align

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -47,18 +47,6 @@
         "url": "https://github.com/nmattia/niv/archive/24eabfbfaa74117d66fa27463a90b237b1b01746.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
-    "nix-hls": {
-        "branch": "master",
-        "description": "Nix builds of Haskell Language Server",
-        "homepage": null,
-        "owner": "shajra",
-        "repo": "nix-hls",
-        "rev": "ab7f2a16174db741d7525dd61e68b3f8f8e926b3",
-        "sha256": "01ganaqf9gg7a1dw1snhkq4dmfwxln6jhdig3iq1q7slcfdqlrg2",
-        "type": "tarball",
-        "url": "https://github.com/shajra/nix-hls/archive/ab7f2a16174db741d7525dd61e68b3f8f8e926b3.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
     "nixpkgs": {
         "branch": "nixos-20.03",
         "description": "Nix Packages collection",

--- a/tools/haskell-language-server/default.nix
+++ b/tools/haskell-language-server/default.nix
@@ -1,5 +1,8 @@
 { fetchFromGitHub
+, haskell-nix
+, makeWrapper
 , sources
+, stdenv
 }:
 
 { project
@@ -11,20 +14,113 @@
 let
   ghcVersion = project.project.pkg-set.options.compiler.nix-name.value;
   index-state = project.project.index-state;
-in
-import sources.nix-hls {
-  inherit ghcVersion index-state index-sha256;
-  sources = {
-    # This has a submodule, which niv doesn't yet handle.
-    # Note that this also defeats nix-prefetch-git.
-    # https://github.com/nmattia/niv/issues/229
-    haskell-language-server =
-      with sources.haskell-language-server;
-      fetchFromGitHub {
-        inherit owner repo rev sha256;
-        name = "haskell-language-server-src";
-        fetchSubmodules = true;
-      };
-    "haskell.nix" = sources.haskell-nix;
+
+  # Most of what follows is inlined https://github.com/shajra/nix-hls.
+  # We tried to call it directly, but getting it to use our nixpkgs
+  # proved irksome.
+
+  planConfigFor = name: modules: {
+    inherit name modules index-state index-sha256;
+    configureArgs = "--disable-benchmarks";
+    compiler-nix-name = ghcVersion;
   };
+
+  allExes = pkg: pkg.components.exes;
+
+  fromSource = name: modules:
+    let
+      planConfig = planConfigFor name modules // {
+        src = sources."${name}";
+      };
+    in
+      allExes (haskell-nix.cabalProject planConfig)."${name}";
+
+  build = fromSource "haskell-language-server"
+    [ { enableSeparateDataOutput = true; } ];
+
+  trueVersion = {
+    "ghc861" = "8.6.1";
+    "ghc862" = "8.6.2";
+    "ghc863" = "8.6.3";
+    "ghc864" = "8.6.4";
+    "ghc865" = "8.6.5";
+    "ghc881" = "8.8.1";
+    "ghc882" = "8.8.2";
+    "ghc883" = "8.8.3";
+    "ghc884" = "8.8.4";
+    "ghc8101" = "8.10.1";
+    "ghc8102" = "8.10.2";
+  }."${ghcVersion}" or (throw "unsupported GHC Version: ${ghcVersion}");
+
+  longDesc = suffix: ''
+    Haskell Language Server (HLS) is the latest attempt make an IDE-like
+    experience for Haskell that's compatible with different editors. HLS
+    implements Microsoft's Language Server Protocol (LSP). With this
+    approach, a background service is launched for a project that answers
+    questions needed by an editor for common IDE features.
+
+    Note that you need a version of HLS compiled specifically for the GHC
+    compiler used by your project.  If you have multiple versions of GHC and
+    HLS installed in your path, then a provided wrapper can be used to
+    select the right one for the version of GHC used by your project.
+
+    ${suffix}
+  '';
+
+  hls = build.haskell-language-server.overrideAttrs (
+    old: {
+      name = "haskell-language-server-${ghcVersion}";
+      meta = old.meta // {
+        description =
+          "Haskell Language Server (HLS) for GHC ${trueVersion}";
+        longDescription = ''
+          This package provides the server executable compiled against
+          ${trueVersion}.  It has the name original name of
+          "haskell-language-server," which may clash with versions compiled for
+          other compilers.
+        '';
+      };
+    }
+  );
+
+  hls-renamed = stdenv.mkDerivation {
+    name = "haskell-language-server-${ghcVersion}-renamed";
+    version = hls.version;
+    phases = [ "installPhase" ];
+    nativeBuildInputs = [ makeWrapper ];
+    installPhase = ''
+      mkdir --parents $out/bin
+      makeWrapper \
+          "${hls}/bin/haskell-language-server" \
+          "$out/bin/haskell-language-server-${trueVersion}"
+    '';
+    meta = hls.meta // {
+      description =
+        "Haskell Language Server (HLS) for GHC ${trueVersion}, renamed binary";
+      longDescription = ''
+        This package provides the server executable compiled against
+        ${trueVersion}.  The binary has been renamed from
+        "haskell-language-server" to "haskell-language-server-${ghcVersion}" to
+        allow Nix to install multiple versions to the same profile for those
+        that wish to use the HLS wrapper.
+      '';
+    };
+  };
+
+  hls-wrapper = build.haskell-language-server-wrapper.overrideAttrs (
+    old: {
+      name = "haskell-language-server-${ghcVersion}-wrapper";
+      meta = old.meta // {
+        description = "Haskell Language Server (HLS) wrapper";
+        longDescription = "This package provides the server wrapper.";
+      };
+    }
+  );
+in
+{
+  inherit
+    hls
+    hls-wrapper
+    hls-renamed
+    ;
 }


### PR DESCRIPTION
nix-hls is instantiating its haskell-nix from one of our haskell-nix's sources' three nixpkgs pins.  We can pick which of the three, but we can't give it our own.  And we've always run haskell-nix with our own nixpkgs pin, so HLS is being built from a different nixpkgs.  

Instead of continuing to accrue hacks to reassemble our sources in the third-party derivation, let's just inline it.  And instead of continuing to speculate, let's test it:

Before:

```
[ross@herbert:~/src/haskell-template]$ nix-store -q -R $(which haskell-language-server) | grep ghc-8.8.3$
/nix/store/pfhrv6llwbri66vq4qg9x5a408qvsgcw-ghc-8.8.3

[ross@herbert:~/src/haskell-template]$ nix-store -q -R $(which ghc) | grep ghc-8.8.3$
/nix/store/z584r6rc2mnws7x43x8khs8lvr6xx96w-ghc-8.8.3
```

After:

```
[ross@herbert:~/src/haskell-template]$ nix-store -q -R $(which haskell-language-server) | grep ghc-8.8.3$
/nix/store/z584r6rc2mnws7x43x8khs8lvr6xx96w-ghc-8.8.3

[ross@herbert:~/src/haskell-template]$ nix-store -q -R $(which ghc) | grep ghc-8.8.3$
/nix/store/z584r6rc2mnws7x43x8khs8lvr6xx96w-ghc-8.8.3
```

:tada: