### PR TITLE
Make project.index-state optional in haskell-language-server

### DIFF
--- a/tools/haskell-language-server/default.nix
+++ b/tools/haskell-language-server/default.nix
@@ -13,7 +13,10 @@
 }:
 let
   ghcVersion = project.project.pkg-set.options.compiler.nix-name.value;
-  index-state = project.project.index-state;
+  index-state =
+    if builtins.hasAttr "index-state" project
+    then project.index-state
+    else null;
 
   # Most of what follows is inlined https://github.com/shajra/nix-hls.
   # We tried to call it directly, but getting it to use our nixpkgs


### PR DESCRIPTION
haskell-nix's `cabalProject`s have an index-state, but not all projects do.  If they don't, null is fine.