### PR TITLE
install-nix-action@v11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v10
+    - uses: cachix/install-nix-action@v11
       with:
         skip_adding_nixpkgs_channel: true
     - uses: cachix/cachix-action@v6


### PR DESCRIPTION
I don't think this solves our MacOS problem, but it's at least faster.

Dependabot (#62) will give us PRs like this for free in the future.