### PR TITLE
Provide haskell-language-servers for user environments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,3 +133,39 @@ jobs:
         name: earnestresearch-public
         signingKey: '${{ secrets.EARNESTRESEARCH_PUBLIC_CACHIX_SIGNING_KEY }}'
     - run: cd test && nix-shell --run "exit 0" --arg buildMusl '${{ matrix.buildMusl }}' --argstr compiler-nix-name '${{ matrix.ghc }}'
+
+  cache-linux-hls:
+    needs: cache-linux-ghc
+    runs-on: [ ubuntu-latest ]
+    strategy:
+      matrix:
+        ghc: [ ghc865, ghc883, ghc884 ]
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+    - uses: cachix/install-nix-action@v11
+      with:
+        skip_adding_nixpkgs_channel: true
+    - uses: cachix/cachix-action@v6
+      with:
+        name: earnestresearch-public
+        signingKey: '${{ secrets.EARNESTRESEARCH_PUBLIC_CACHIX_SIGNING_KEY }}'
+    - run: nix-build -E "(import ./.).tools.haskellLanguageServersFor [ \"${{ matrix.ghc }}\" ]"
+
+  cache-macos-hls:
+    needs: cache-macos-ghc
+    runs-on: [ macos-latest ]
+    strategy:
+      matrix:
+        ghc: [ ghc865, ghc883, ghc884 ]
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+    - uses: cachix/install-nix-action@v11
+      with:
+        skip_adding_nixpkgs_channel: true
+    - uses: cachix/cachix-action@v6
+      with:
+        name: earnestresearch-public
+        signingKey: '${{ secrets.EARNESTRESEARCH_PUBLIC_CACHIX_SIGNING_KEY }}'
+    - run: nix-build -E "(import ./.).tools.haskellLanguageServersFor [ \"${{ matrix.ghc }}\" ]"

--- a/README.md
+++ b/README.md
@@ -159,18 +159,27 @@ One reason they're distinct from packages is that they may require arguments to 
 
 [Haskell Language Server](https://github.com/haskell/haskell-language-server) is a language server implementation that should work in any editor with an LSP client.
 It must be compiled with the same version of `ghc` as used by the project.
-We provide a function here to build HLS binaries for your `haskell.nix` project.
-The nix name of your GHC and the Hackage index state are inferred from the project.
-To add it to your `shell.nix`:
+We provide a function here to fetch the `haskell-language-server-wrapper` and cached `haskell-language-server` binaries for various Haskell versions.
+To add it to your environment:
+
+```sh
+nix-env -if https://github.com/EarnestResearch/er-nix/tarball/master -A tools.haskell-language-servers
+```
+
+home-manager users can add the values to `home.packages`:
 
 ```nix
 let
-  hls = er-nix.tools.haskell-language-server { project = hsPkgs.earnest-project };
-in
-hsPkgs.shellFor {
-  buildInputs = [ ... ] ++ builtins.attrValues hls;
+  er-nix = import sources.er-nix;
+{
+  home.packages = [
+    # Your other nixpkgs here
+  ] ++ builtins.attrValues er-nix.tools.haskell-language-servers;
 }
 ```
+
+There is also a `tools.haskellLanguageServersFor` function that takes an array of ghcVersions, but this isn't guaranteed to be in our cachix.
+If you need more, please consider a PR here.
 
 ## Development
 

--- a/default.nix
+++ b/default.nix
@@ -29,10 +29,18 @@ rec {
 
   inherit (import sources.niv {}) niv;
 
-  tools = {
+  tools = rec {
     haskell-language-server =
-      pkgs.callPackage ./tools/haskell-language-server {
-        inherit sources;
+      { ... }@args: pkgs.lib.warn "haskell-language-server is deprecated.  Install haskellLanguageServersFor(ghcVersions) to your environment."
+        pkgs.callPackage ./tools/haskell-language-server/hls.nix
+        {}
+        ({ inherit sources; } // args);
+
+    haskell-language-servers = haskellLanguageServersFor [ "ghc865" "ghc884" ];
+
+    haskellLanguageServersFor = ghcVersions:
+      pkgs.callPackage ./tools/haskell-language-server/hlsFor.nix {} {
+        inherit ghcVersions sources;
       };
   };
 }

--- a/test/shell.nix
+++ b/test/shell.nix
@@ -5,7 +5,6 @@ let
   er-nix = import ../default.nix;
   pkgs = er-nix.pkgs;
   hsPkgs = import ./default.nix { inherit pkgs buildMusl compiler-nix-name; };
-  hls = er-nix.tools.haskell-language-server { project = hsPkgs.earnest-project; };
 in
 hsPkgs.shellFor {
   tools = {
@@ -13,5 +12,5 @@ hsPkgs.shellFor {
     hpack = "0.34.2";
   };
 
-  buildInputs = builtins.attrValues hls;
+  buildInputs = [];
 }

--- a/tools/haskell-language-server/default.nix
+++ b/tools/haskell-language-server/default.nix
@@ -1,23 +1,15 @@
 { fetchFromGitHub
 , haskell-nix
 , makeWrapper
-, sources
 , stdenv
 }:
 
-{ project
-, # We can't infer this, which is fine as long as we're using a hashed
-  # one.  We're just overriding nix-hls' pin here so haskell.nix looks
-  # it up in its own indexStateHashesPath.
-  index-sha256 ? null
+{ ghcVersion
+, sources
+, index-state
+, index-sha256
 }:
 let
-  ghcVersion = project.project.pkg-set.options.compiler.nix-name.value;
-  index-state =
-    if builtins.hasAttr "index-state" project
-    then project.index-state
-    else null;
-
   # Most of what follows is inlined https://github.com/shajra/nix-hls.
   # We tried to call it directly, but getting it to use our nixpkgs
   # proved irksome.

--- a/tools/haskell-language-server/hls.nix
+++ b/tools/haskell-language-server/hls.nix
@@ -1,0 +1,22 @@
+{ callPackage }:
+
+{ project
+, # We can't infer this, which is fine as long as we're using a hashed one.
+  # We're just overriding nix-hls' pin here so haskell.nix looks
+  # it up in its own indexStateHashesPath.
+  index-sha256 ? null
+, sources
+}:
+let
+  hlsPkgs = callPackage ./. {} {
+    inherit sources index-sha256;
+    ghcVersion = project.project.pkg-set.options.compiler.nix-name.value;
+    index-state =
+      if builtins.hasAttr "index-state" project
+      then project.index-state
+      else null;
+  };
+in
+{
+  inherit (hlsPkgs) hls-wrapper hls-renamed;
+}

--- a/tools/haskell-language-server/hlsFor.nix
+++ b/tools/haskell-language-server/hlsFor.nix
@@ -1,0 +1,18 @@
+{ callPackage }:
+
+{ ghcVersions
+, sources
+}:
+let
+  hlsPkgs = ghcVersion: callPackage ./. {} {
+    inherit ghcVersion sources;
+    index-state = null;
+    index-sha256 = null;
+  };
+  wrapperGhcVersion = builtins.head ghcVersions;
+in
+builtins.foldl' (bins: ghcv: bins // {
+  "haskell-language-server-${ghcv}" = (hlsPkgs ghcv).hls-renamed;
+}) {
+  "haskell-language-server-wrapper" = (hlsPkgs wrapperGhcVersion).hls-wrapper;
+} ghcVersions


### PR DESCRIPTION
Switch from per-project HLS installations to a set that can be installed with `nix-env` or home-manager.  This is more like the vscode plugin model, but also works nicely in other editors.

By no longer carefully to the project's haskell.nix, we are now reliant on haskell.nix's binary compatibility with same-named GHC versions.  This hasn't been a problem in several months. :crossed_fingers:.