### PR TITLE
Cache ghcide-0.4.0

### DIFF
--- a/test/shell.nix
+++ b/test/shell.nix
@@ -9,6 +9,7 @@ in
 hsPkgs.shellFor {
   tools = {
     cabal = "3.2.0.0";
+    ghcide = "0.4.0";
     hpack = "0.34.2";
   };
 


### PR DESCRIPTION
haskell-language-server is still struggling to digest aws-cfn-stacks. This gets the latest ghcide in cachix until everyone is migrated.