### PR TITLE
Upgrade bot

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,6 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
-      with:
-        ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
     - uses: cachix/install-nix-action@v12
       with:
         skip_adding_nixpkgs_channel: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,4 +168,7 @@ jobs:
       with:
         name: earnestresearch-public
         signingKey: '${{ secrets.EARNESTRESEARCH_PUBLIC_CACHIX_SIGNING_KEY }}'
-    - run: nix-build -E "(import ./.).tools.haskellLanguageServersFor [ \"${{ matrix.ghc }}\" ]"
+    - name: Cache shell dependencies
+      run: nix-shell --command 'exit 0'
+    - name: Build Haskell Language Servers
+      run: nix-build -E "(import ./.).tools.haskellLanguageServersFor [ \"${{ matrix.ghc }}\" ]"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,6 +169,6 @@ jobs:
         name: earnestresearch-public
         signingKey: '${{ secrets.EARNESTRESEARCH_PUBLIC_CACHIX_SIGNING_KEY }}'
     - name: Cache shell dependencies
-      run: nix-shell --command 'exit 0'
+      run: nix-shell --command true
     - name: Build Haskell Language Servers
       run: nix-build -E "(import ./.).tools.haskellLanguageServersFor [ \"${{ matrix.ghc }}\" ]"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
+      with:
+        ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
     - uses: cachix/install-nix-action@v11
       with:
         skip_adding_nixpkgs_channel: true

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -6,7 +6,8 @@ on:
     - cron: '00 08 1-7,15-21 * 2'
   workflow_dispatch:
   push:
-    - upggrade-bot
+    branches:
+      - upgrade-bot
 jobs:
   create-pull-request:
     runs-on: ubuntu-latest

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     # First and third Tuesday of every month at 8am
     - cron: '00 08 1-7,15-21 * 2'
+  workflow_dispatch:
 jobs:
   create-pull-request:
     runs-on: ubuntu-latest

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         name: earnestresearch-public
     - name: Update dependencies
-      run: niv update
+      run: nix-shell --command 'niv update'
     - name: Update test cabal.project.freeze to latest LTS
       run: curl -L https://www.stackage.org/lts/cabal.config > test/cabal.project.freeze
     - name: Create pull request

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -18,6 +18,8 @@ jobs:
       with:
         name: earnestresearch-public
     - name: Update dependencies
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: nix-shell --command 'niv update'
     - name: Update test cabal.project.freeze to latest LTS
       run: curl -L https://www.stackage.org/lts/cabal.config > test/cabal.project.freeze

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -5,6 +5,8 @@ on:
     # First and third Tuesday of every month at 8am
     - cron: '00 08 1-7,15-21 * 2'
   workflow_dispatch:
+  push:
+    - upggrade-bot
 jobs:
   create-pull-request:
     runs-on: ubuntu-latest

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -2,8 +2,8 @@ name: Upgrade Niv and LTS
 
 on:
   schedule:
-    # First and third Tuesday of every month at 8am
-    - cron: '00 08 1-7,15-21 * 2'
+    # Second and fourth Tuesday of every month at 8am
+    - cron: '00 08 8-14,22-28 * 2'
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -13,9 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v11
-      with:
-        skip_adding_nixpkgs_channel: true
+    - uses: cachix/install-nix-action@v12
     - uses: cachix/cachix-action@v7
       with:
         name: earnestresearch-public

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -1,0 +1,26 @@
+name: Upgrade Niv and LTS
+
+jobs:
+  create-pull-request:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: cachix/install-nix-action@v11
+      with:
+        skip_adding_nixpkgs_channel: true
+    - uses: cachix/cachix-action@v7
+      with:
+        name: earnestresearch-public
+    - name: Update dependencies
+      run: niv update
+    - name: Update test cabal.project.freeze to latest LTS
+      run: curl -L https://www.stackage.org/lts/cabal.config > test/cabal.project.freeze
+    - name: Create pull request
+      id: cpr
+      uses: peter-evans/create-pull-request@v3
+      with:
+        commit-message: Niv and LTS upgrades
+        committer: er-nix-bot <noreply@earnestresearch.com>
+        branch: create-pull-request/upgrade
+        delete-branch: true
+        title: Niv and LTS upgrades

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -5,6 +5,9 @@ on:
     # Second and fourth Tuesday of every month at 8am
     - cron: '00 08 8-14,22-28 * 2'
   workflow_dispatch:
+  push:
+    branches:
+      - upgrade-bot
 jobs:
   create-pull-request:
     runs-on: ubuntu-latest

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
     - uses: cachix/install-nix-action@v12
     - uses: cachix/cachix-action@v7
       with:

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -20,8 +20,7 @@ jobs:
     - name: Update dependencies
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_PATH:
-      run: nix-shell --command 'niv update'
+      run: GITHUB_PATH= nix-shell --command 'niv update'
     - name: Update test cabal.project.freeze to latest LTS
       run: curl -L https://www.stackage.org/lts/cabal.config > test/cabal.project.freeze
     - name: Create pull request

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -5,9 +5,6 @@ on:
     # Second and fourth Tuesday of every month at 8am
     - cron: '00 08 8-14,22-28 * 2'
   workflow_dispatch:
-  push:
-    branches:
-      - upgrade-bot
 jobs:
   create-pull-request:
     runs-on: ubuntu-latest

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -1,5 +1,9 @@
 name: Upgrade Niv and LTS
 
+on:
+  schedule:
+    # First and third Tuesday of every month at 8am
+    - cron: '00 08 1-7,15-21 * 2'
 jobs:
   create-pull-request:
     runs-on: ubuntu-latest

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -20,6 +20,7 @@ jobs:
     - name: Update dependencies
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_PATH:
       run: nix-shell --command 'niv update'
     - name: Update test cabal.project.freeze to latest LTS
       run: curl -L https://www.stackage.org/lts/cabal.config > test/cabal.project.freeze

--- a/README.md
+++ b/README.md
@@ -196,3 +196,7 @@ To update all sources:
 ```sh
 niv update
 ```
+
+### Automated updates
+
+The `upgrade.yml` workflow runs a niv update and fetches the latest LTS on the second and fourth Tuesday of every month.


### PR DESCRIPTION
Runs `niv upgrade` and curls the latest LTS into our test our cachix stays primed with modern comforts.  Currently scheduled to run every second and fourth Tuesday.