### PR TITLE
Simpler cron expression for upgrades

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -2,8 +2,7 @@ name: Upgrade Niv and LTS
 
 on:
   schedule:
-    # Second and fourth Tuesday of every month at 8am
-    - cron: '00 08 8-14,22-28 * 2'
+    - cron: '0 8 9,24 * *'
   workflow_dispatch:
 jobs:
   create-pull-request:


### PR DESCRIPTION
The old one was Stack Overflow Certified™ and POSIX compliant, but GitHub Actions has been running it every day this week in spite of the trailing `2`.

This one is boring and might run on weekends but boring crons are good.