### PR TITLE
Switch to nixpkgs-master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,13 +14,14 @@ jobs:
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v12
       with:
-        skip_adding_nixpkgs_channel: true
+        nix_path: nixpkgs=channel:nixos-unstable
     - uses: cachix/cachix-action@v8
       with:
         name: earnestresearch-public
         signingKey: '${{ secrets.EARNESTRESEARCH_PUBLIC_CACHIX_SIGNING_KEY }}'
     - run: cachix use pre-commit-hooks
-    - run: nix-build -E "(import ./.).pkgs.pre-commit-hooks"
+    - run: nix-env -i coreutils -f '<nixpkgs>'
+    - run: timeout -v -k 1m 400m nix-build -E "(import ./.).pkgs.pre-commit-hooks"
 
   cache-haskell-nix-roots:
     runs-on: ${{ matrix.os }}
@@ -34,12 +35,13 @@ jobs:
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v12
       with:
-        skip_adding_nixpkgs_channel: true
+        nix_path: nixpkgs=channel:nixos-unstable
     - uses: cachix/cachix-action@v8
       with:
         name: earnestresearch-public
         signingKey: '${{ secrets.EARNESTRESEARCH_PUBLIC_CACHIX_SIGNING_KEY }}'
-    - run: nix-build -E '(import ./.).${{ matrix.pkgs }}.haskell-nix.roots "${{ matrix.ghc }}"'
+    - run: nix-env -i coreutils -f '<nixpkgs>'
+    - run: timeout -v -k 1m 400m nix-build -E '(import ./.).${{ matrix.pkgs }}.haskell-nix.roots "${{ matrix.ghc }}"'
 
   cache-ghc:
     needs: cache-haskell-nix-roots
@@ -54,12 +56,13 @@ jobs:
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v12
       with:
-        skip_adding_nixpkgs_channel: true
+        nix_path: nixpkgs=channel:nixos-unstable
     - uses: cachix/cachix-action@v8
       with:
         name: earnestresearch-public
         signingKey: '${{ secrets.EARNESTRESEARCH_PUBLIC_CACHIX_SIGNING_KEY }}'
-    - run: nix-build -E "(import ./.).${{ matrix.pkgs }}.buildPackages.haskell-nix.compiler.${{ matrix.ghc }}"
+    - run: nix-env -i coreutils -f '<nixpkgs>'
+    - run: timeout -v -k 1m 400m nix-build -E "(import ./.).${{ matrix.pkgs }}.buildPackages.haskell-nix.compiler.${{ matrix.ghc }}"
 
   cache-projects:
     needs: cache-ghc
@@ -74,12 +77,13 @@ jobs:
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v12
       with:
-        skip_adding_nixpkgs_channel: true
+        nix_path: nixpkgs=channel:nixos-unstable
     - uses: cachix/cachix-action@v8
       with:
         name: earnestresearch-public
         signingKey: '${{ secrets.EARNESTRESEARCH_PUBLIC_CACHIX_SIGNING_KEY }}'
-    - run: cd test && nix-shell --run "exit 0" --arg buildMusl '${{ matrix.buildMusl }}' --argstr compiler-nix-name '${{ matrix.ghc }}'
+    - run: nix-env -i coreutils -f '<nixpkgs>'
+    - run: cd test && timeout -v -k 1m 400m nix-shell --run "exit 0" --arg buildMusl '${{ matrix.buildMusl }}' --argstr compiler-nix-name '${{ matrix.ghc }}'
 
   cache-hls:
     needs: cache-ghc
@@ -93,9 +97,10 @@ jobs:
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v12
       with:
-        skip_adding_nixpkgs_channel: true
+        nix_path: nixpkgs=channel:nixos-unstable
     - uses: cachix/cachix-action@v8
       with:
         name: earnestresearch-public
         signingKey: '${{ secrets.EARNESTRESEARCH_PUBLIC_CACHIX_SIGNING_KEY }}'
-    - run: nix-build -E "(import ./.).tools.haskellLanguageServersFor [ \"${{ matrix.ghc }}\" ]"
+    - run: nix-env -i coreutils -f '<nixpkgs>'
+    - run: timeout -v -k 1m 400m nix-build -E "(import ./.).tools.haskellLanguageServersFor [ \"${{ matrix.ghc }}\" ]"

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ let
 We use [niv](https://github.com/nmattia/niv) to manage our source pins.  `niv` is available in the nix-shell for this project.  To update a single source:
 
 ```sh
-niv update nixpkgs-unstable
+niv update nixpkgs
 ```
 
 To update all sources:

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -48,27 +48,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "nixos-20.03",
-        "description": "Nix Packages collection",
-        "homepage": "https://github.com/NixOS/nixpkgs",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "eb86687de94beec0365e7679f27eb6c044240967",
-        "sha256": "1c3rbadv4m6cgpzl6mbnmhj7rzam3629bmsrc1yjimwc9izirz4n",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/eb86687de94beec0365e7679f27eb6c044240967.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "nixpkgs-unstable": {
         "branch": "master",
         "description": "Nix Packages collection",
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8d5eb691015063863e5f962268d62c24b73c6ca7",
-        "sha256": "1rxzq9lm5spgs4h4pijvzcbx5fk07kxa3dmgqac6638x9hq79d77",
+        "rev": "5420a929261beff7b300be574dd6106ab736aec2",
+        "sha256": "1nmlpgh7mzndynkxg37sbz5mrz3m67rys28kyy41cmhmyjc8hfvb",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/8d5eb691015063863e5f962268d62c24b73c6ca7.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5420a929261beff7b300be574dd6106ab736aec2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "okta-aws-login": {


### PR DESCRIPTION
The nixpkgs-20.03 we've been using doesn't work for Big Sur.  20.09 won't, either.  Moving to master should fix it, though it will negatively impact how much we can piggyback off the upstream nix-tools cache.

Dropped the old `nixpkgs-unstable` alias, which was unused, and now equivalent to `nixpkgs`.