### PR TITLE
Working around undmg segfault

### DIFF
--- a/pkgs/snowflake-odbc/default.nix
+++ b/pkgs/snowflake-odbc/default.nix
@@ -62,7 +62,7 @@ let
     nativeBuildInputs = [ undmg xar cpio ];
 
     unpackPhase = stdenv.lib.optionalString stdenv.isDarwin ''
-      undmg < $src
+      undmg $src
       xar -xf snowflakeODBC.pkg
       zcat Payload | cpio -i
     '';


### PR DESCRIPTION
[undmg](https://github.com/matthewbauer/undmg) isn't super-well documented and doesn't seem to have a version number, but anyways after a niv update I stumbled upon this odd behavior when passing a file to it on stdin:

```
% undmg < ~/Downloads/snowflake_odbc_mac-2.22.3.dmg
zsh: segmentation fault  undmg < ~/Downloads/snowflake_odbc_mac-2.22.3.dmg
```

Just using `undmg filename` seems to work fine, though:

```
% undmg ~/Downloads/snowflake_odbc_mac-2.22.3.dmg

% ls
snowflakeODBC.pkg
```

...so this updates the snowflake-odbc package to use the form that doesn't segfault.