### PR TITLE
haskell-language-server-0.8.0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -12,15 +12,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskell-language-server": {
-        "branch": "0.7.0",
+        "branch": "0.8.0",
         "description": "Integration point for ghcide and haskell-ide-engine. One IDE to rule them all.",
         "homepage": null,
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "6a692de3308c06d8eb7bdf0f7b8a35b6e9a92610",
-        "sha256": "15aji3639ry6ldhrai7lxs75fjycj5xwjdv3h0rfgxm39fk69xgv",
+        "rev": "eb58f13f7b8e4f9bc771af30ff9fd82dc4309ff5",
+        "sha256": "0p6fqs07lajbi2g1wf4w3j5lvwknnk58n12vlg48cs4iz25gp588",
         "type": "tarball",
-        "url": "https://github.com/haskell/haskell-language-server/archive/6a692de3308c06d8eb7bdf0f7b8a35b6e9a92610.tar.gz",
+        "url": "https://github.com/haskell/haskell-language-server/archive/eb58f13f7b8e4f9bc771af30ff9fd82dc4309ff5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskell-nix": {

--- a/tools/haskell-language-server/default.nix
+++ b/tools/haskell-language-server/default.nix
@@ -59,6 +59,7 @@ let
     "ghc884" = "8.8.4";
     "ghc8101" = "8.10.1";
     "ghc8102" = "8.10.2";
+    "ghc8103" = "8.10.3";
   }."${ghcVersion}" or (throw "unsupported GHC Version: ${ghcVersion}");
 
   longDesc = suffix: ''


### PR DESCRIPTION
Purportedly supports ghc-8.10.3, which we're not caching yet, but that's another bump to consider.