### PR TITLE
Only use one hackage snapshot in nix build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         signingKey: '${{ secrets.EARNESTRESEARCH_PUBLIC_CACHIX_SIGNING_KEY }}'
     - run: cachix use pre-commit-hooks
     - run: nix-env -i coreutils -f '<nixpkgs>'
-    - run: timeout -v -k 1m 400m nix-build -E "(import ./.).pkgs.pre-commit-hooks"
+    - run: timeout -v -k 1m 340m nix-build -E "(import ./.).pkgs.pre-commit-hooks"
 
   cache-haskell-nix-roots:
     runs-on: ${{ matrix.os }}
@@ -41,31 +41,10 @@ jobs:
         name: earnestresearch-public
         signingKey: '${{ secrets.EARNESTRESEARCH_PUBLIC_CACHIX_SIGNING_KEY }}'
     - run: nix-env -i coreutils -f '<nixpkgs>'
-    - run: timeout -v -k 1m 400m nix-build -E '(import ./.).${{ matrix.pkgs }}.haskell-nix.roots "${{ matrix.ghc }}"'
-
-  cache-ghc:
-    needs: cache-haskell-nix-roots
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, macos-latest ]
-        ghc: [ ghc865, ghc884, ghc8101 ]
-        pkgs: [ pkgs ]
-      fail-fast: false
-    steps:
-    - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v12
-      with:
-        nix_path: nixpkgs=channel:nixos-unstable
-    - uses: cachix/cachix-action@v8
-      with:
-        name: earnestresearch-public
-        signingKey: '${{ secrets.EARNESTRESEARCH_PUBLIC_CACHIX_SIGNING_KEY }}'
-    - run: nix-env -i coreutils -f '<nixpkgs>'
-    - run: timeout -v -k 1m 400m nix-build -E "(import ./.).${{ matrix.pkgs }}.buildPackages.haskell-nix.compiler.${{ matrix.ghc }}"
+    - run: timeout -v -k 1m 340m nix-build -E '(import ./.).${{ matrix.pkgs }}.haskell-nix.roots "${{ matrix.ghc }}"'
 
   cache-projects:
-    needs: cache-ghc
+    needs: cache-haskell-nix-roots
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -83,10 +62,10 @@ jobs:
         name: earnestresearch-public
         signingKey: '${{ secrets.EARNESTRESEARCH_PUBLIC_CACHIX_SIGNING_KEY }}'
     - run: nix-env -i coreutils -f '<nixpkgs>'
-    - run: cd test && timeout -v -k 1m 400m nix-shell --run "exit 0" --arg buildMusl '${{ matrix.buildMusl }}' --argstr compiler-nix-name '${{ matrix.ghc }}'
+    - run: cd test && timeout -v -k 1m 340m nix-shell --run "exit 0" --arg buildMusl '${{ matrix.buildMusl }}' --argstr compiler-nix-name '${{ matrix.ghc }}'
 
   cache-hls:
-    needs: cache-ghc
+    needs: cache-haskell-nix-roots
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -103,4 +82,4 @@ jobs:
         name: earnestresearch-public
         signingKey: '${{ secrets.EARNESTRESEARCH_PUBLIC_CACHIX_SIGNING_KEY }}'
     - run: nix-env -i coreutils -f '<nixpkgs>'
-    - run: timeout -v -k 1m 400m nix-build -E "(import ./.).tools.haskellLanguageServersFor [ \"${{ matrix.ghc }}\" ]"
+    - run: timeout -v -k 1m 340m nix-build -E "(import ./.).tools.haskellLanguageServersFor [ \"${{ matrix.ghc }}\" ]"

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,10 @@
 let
   sources = import ./nix/sources.nix;
-  haskell-nix = import sources.haskell-nix {};
+  haskell-nix = import sources.haskell-nix {
+    sourcesOverride = {
+      nixpkgs = sources.nixpkgs;
+    };
+  };
 in
 rec {
   # A pinned version of nixpkgs, widely used and hopefully well cached.


### PR DESCRIPTION
haskell.nix uses its own hackage snapshot unless overridden.
There seems little point in having two snapshots in use, it's a lot more work, especially for simple builds.

Override as per https://github.com/input-output-hk/haskell.nix/blob/master/docs/tutorials/hackage-stackage.md
