### PR TITLE
Support ghc-8.10.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
-        ghc: [ ghc865, ghc884, ghc8101 ]
+        ghc: [ ghc865, ghc884, ghc8104 ]
         pkgs: [ pkgs ]
       fail-fast: false
     steps:
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
-        ghc: [ ghc865, ghc884 ]
+        ghc: [ ghc865, ghc884, ghc8104 ]
         buildMusl: [ false ]
       fail-fast: false
     steps:
@@ -70,7 +70,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
-        ghc: [ ghc865, ghc884 ]
+        ghc: [ ghc865, ghc884, ghc8104 ]
       fail-fast: false
     steps:
     - uses: actions/checkout@v2

--- a/default.nix
+++ b/default.nix
@@ -40,7 +40,7 @@ rec {
         {}
         ({ inherit sources; } // args);
 
-    haskell-language-servers = haskellLanguageServersFor [ "ghc865" "ghc884" ];
+    haskell-language-servers = haskellLanguageServersFor [ "ghc865" "ghc884" "ghc8104" ];
 
     haskellLanguageServersFor = ghcVersions:
       pkgs.callPackage ./tools/haskell-language-server/hlsFor.nix {} {

--- a/tools/haskell-language-server/default.nix
+++ b/tools/haskell-language-server/default.nix
@@ -60,6 +60,7 @@ let
     "ghc8101" = "8.10.1";
     "ghc8102" = "8.10.2";
     "ghc8103" = "8.10.3";
+    "ghc8104" = "8.10.4";
   }."${ghcVersion}" or (throw "unsupported GHC Version: ${ghcVersion}");
 
   longDesc = suffix: ''


### PR DESCRIPTION
The latest LTS is 8.10.4, and things are getting creaky on LTS-16.